### PR TITLE
Update CommonTokenStream.cs

### DIFF
--- a/runtime/CSharp/Antlr4.Runtime/CommonTokenStream.cs
+++ b/runtime/CSharp/Antlr4.Runtime/CommonTokenStream.cs
@@ -123,7 +123,14 @@ namespace Antlr4.Runtime
 
         protected internal override int AdjustSeekIndex(int i)
         {
-            return NextTokenOnChannel(i, channel);
+           var result = NextTokenOnChannel(i, channel);
+            if (result == -1) // if -1 would be returned, the parse would continue at the start again
+            {
+                result = tokens.Count - 1;
+                // at this point the EOF has been seen, so tokens.Count - 1 points at EOF
+                System.Diagnostics.Debug.Assert(tokens[result].Type == IntStreamConstants.Eof);
+            }
+            return result;
         }
 
         protected internal override IToken Lb(int k)


### PR DESCRIPTION
Using the `CommonTokenStream` with a non-default channel for parsing results in an endless loop since `Consume` (which calls `AdjustSeekIndex` at the end) sets the token index to the start after the last consumed token on the desired channel.

Also see http://stackoverflow.com/questions/24178375/parsing-a-non-default-channel-results-in-an-endless-loop
